### PR TITLE
Added an Assignment Template Model to DB

### DIFF
--- a/src/routes/template_setup.js
+++ b/src/routes/template_setup.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const router = require('express').Router();
+
+const Template = require('../templates'); 
+const assignmentFields = require('../template_fields/assignment_fields');
+
+/**
+ * GET /test-template
+ * Route to create a new assignment template and return it as JSON.
+ * This is mainly for testing or initial setup purposes.
+ */
+router.get('/test-template', async (req, res) => {
+	try {
+		const template = await Template.create({
+			title: 'Assignment Template',
+			fields: assignmentFields,
+		});
+
+		// Respond with success status and the created template data
+		res.json({
+			success: true,
+			template,
+		});
+	} catch (err) {
+		console.error('Error creating template:', err);
+
+		// Respond with a 500 status and error message
+		res.status(500).json({
+			success: false,
+			error: err.message,
+		});
+	}
+});
+
+module.exports = router;

--- a/src/template_fields/assignment_fields.js
+++ b/src/template_fields/assignment_fields.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const assignmentFields = [
+	{ key: 'course', label: 'Course', type: 'text', required: true },
+	{ key: 'assignment_name', label: 'Assignment Name', type: 'text', required: true },
+	{ key: 'due_date', label: 'Due Date', type: 'text', required: true },
+	{ key: 'due_time', label: 'Due Time', type: 'text', required: true },
+	{ key: 'weight', label: 'Weight', type: 'text', required: false },
+	{ key: 'description', label: 'Assignment Description', type: 'textarea', required: true },
+	{ key: 'example_solution', label: 'Example Solution', type: 'textarea', required: false },
+	{ key: 'faqs', label: 'FAQs', type: 'textarea', required: false },
+	{ key: 'late_policy', label: 'Late Policy', type: 'textarea', required: false },
+	{ key: 'resources', label: 'Resources', type: 'textarea', required: false },
+];
+
+module.exports = assignmentFields;

--- a/src/templates.js
+++ b/src/templates.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const db = require.main.require('./src/database');
+const { v4: uuidv4 } = require('uuid');
+
+const TEMPLATE_PREFIX = 'template:';
+const TEMPLATE_LIST = 'templates:all';
+
+//Empty object to hold methods
+const Template = {};
+
+/**
+ * Create a new template and store it in the database
+ * @returns The saved template object
+ */
+Template.create = async function ({ title, fields }) {
+	const id = uuidv4();
+	const now = Date.now();
+
+	const template = {
+		id,
+		title,
+		visibility: 'public',
+		fields,
+		tagMap: {}, // future feature
+		version: 1,
+		createdAt: now,
+		updatedAt: now,
+	};
+
+	await db.setObject(`${TEMPLATE_PREFIX}${id}`, template);
+	await db.sortedSetAdd(TEMPLATE_LIST, now, id);
+
+	return template;
+};
+
+/**
+ * Get a single template by its ID
+ * @returns The template object or null if not found
+ */
+Template.get = async function (id) {
+	return await db.getObject(`${TEMPLATE_PREFIX}${id}`);
+};
+
+/**
+ * Get all templates in the database, ordered by creation time
+ * @returns An array of all template objects
+ */
+Template.list = async function () {
+	const ids = await db.getSortedSetRange(TEMPLATE_LIST, 0, -1);
+	const keys = ids.map(id => `${TEMPLATE_PREFIX}${id}`);
+	return await db.getObjects(keys);
+};
+
+module.exports = Template;


### PR DESCRIPTION
## Summary

The changes includes the creation of a scalable template data model, along with an API endpoint for inserting a test template into the Redis database.

Key tasks completed:

- Created `src/templates.js` core helper module to create, retrieve, and list templates from Redis.
- Added a new API route to insert the template for testing purposes.

## Testing

- Temporarily mounted the route in the main router to support the setup process through NodeBB server.
- Started the NodeBB server `./nodebb start`
- Sent a request to create the template:
- `curl http://localhost:4567/api/template_setup/test-template`
- Confirmed the returned JSON contained the correct template structure and metadata.
- Redis (database) Check
      `redis-cli`
      `ZRANGE templates:all 0 -1`
- Verified that the inserted template ID was present in the Redis store.

Closes #3