### PR TITLE
feat(polls): add GET /api/posts/:pid/poll (Issue 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ test.sh
 
 .docker/**
 !**/.gitkeep
+
+# local junk
+eslint/
+nodebb@4.4.6/

--- a/src/meta/logs.js
+++ b/src/meta/logs.js
@@ -8,9 +8,27 @@ const Logs = module.exports;
 Logs.path = path.resolve(__dirname, '../../logs/output.log');
 
 Logs.get = async function () {
-	return await fs.promises.readFile(Logs.path, 'utf-8');
+	try {
+		return await fs.promises.readFile(Logs.path, 'utf-8');
+	} catch (err) {
+		if (err && err.code === 'ENOENT') {
+			return '';
+		}
+		throw err;
+	}
 };
 
 Logs.clear = async function () {
-	await fs.promises.truncate(Logs.path, 0);
+	try {
+		await fs.promises.truncate(Logs.path, 0);
+	} catch (err) {
+		if (err && err.code === 'ENOENT') {
+			await fs.promises.mkdir(path.dirname(Logs.path), { recursive: true });
+			await fs.promises.writeFile(Logs.path, '');
+			return;
+		}
+		throw err;
+	}
 };
+
+

--- a/src/polls/model.js
+++ b/src/polls/model.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const db = require.main.require('./src/database');
+const { v4: uuid } = require('uuid');
+
+const PollModel = {
+	/**
+	 * Create a poll and index it by postId.
+	 * @param {Object} p
+	 * @param {string|number} p.postId
+	 * @param {string} p.question
+	 * @param {string[]} p.options - at least 2
+	 * @param {string|number} p.createdBy
+	 * @param {number|null} [p.closesAt]
+	 */
+	async createPoll({ postId, question, options, createdBy, closesAt = null }) {
+		if (!postId || !question || !Array.isArray(options) || options.length < 2) {
+			throw new Error('Invalid poll: need postId, question, and at least 2 options');
+		}
+
+		const pollId = uuid();
+
+		const pollKey = `poll:${pollId}`;
+		const data = {
+			pollId,
+			postId: String(postId),
+			question: String(question),
+			options: JSON.stringify(options),
+			createdBy: String(createdBy ?? ''),
+			createdAt: String(Date.now()),
+			closesAt: closesAt ? String(closesAt) : '',
+		};
+
+		// Store main poll object
+		await db.setObject(pollKey, data);
+
+		// Index polls by post (future-proof if you ever allow >1 poll/post)
+		await db.setAdd(`poll:byPost:${postId}`, pollId);
+
+		// Initialize counts for each option to 0
+		const counts = {};
+		options.forEach((_, idx) => { counts[idx] = 0; });
+		await db.setObject(`poll:counts:${pollId}`, counts);
+
+		return { ...data, options };
+	},
+
+	async getPollById(pollId) {
+		const obj = await db.getObject(`poll:${pollId}`);
+		if (!obj || !obj.pollId) return null;
+		return { ...obj, options: JSON.parse(obj.options || '[]') };
+	},
+
+	async getPollIdsByPostId(postId) {
+		return db.getSetMembers(`poll:byPost:${postId}`);
+	},
+
+	// Common case: one poll per post — return the first if it exists
+	async getPollByPostId(postId) {
+		const ids = await db.getSetMembers(`poll:byPost:${postId}`);
+		if (!ids || !ids.length) return null;
+		return this.getPollById(ids[0]);
+	},
+};
+
+module.exports = PollModel;

--- a/src/polls/votes.js
+++ b/src/polls/votes.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const db = require.main.require('./src/database');
+
+const Votes = {
+	/**
+	 * Check if a user already voted in a poll
+	 */
+	async hasUserVoted(pollId, userId) {
+		return db.isSetMember(`poll:voters:${pollId}`, String(userId));
+	},
+
+	/**
+	 * Record a vote and increment counts.
+	 * Throws { code: 'ALREADY_VOTED' } if same user votes again.
+	 */
+	async recordVote({ pollId, userId, optionIndex }) {
+		if (!pollId || !userId || typeof optionIndex !== 'number' || Number.isNaN(optionIndex)) {
+			const e = new Error('Missing pollId/userId or bad optionIndex');
+			e.code = 'BAD_INPUT';
+			throw e;
+		}
+
+		// Uniqueness: check first, then add
+		const already = await db.isSetMember(`poll:voters:${pollId}`, String(userId));
+		if (already) {
+			const err = new Error('User has already voted on this poll');
+			err.code = 'ALREADY_VOTED';
+			throw err;
+		}
+		await db.setAdd(`poll:voters:${pollId}`, String(userId));
+
+		// Optional: store the user’s choice
+		await db.setObject(`poll:vote:${pollId}:${userId}`, {
+			optionIndex: String(optionIndex),
+			createdAt: String(Date.now()),
+		});
+
+		// Increment aggregate count for the chosen option
+		await db.incrObjectField(`poll:counts:${pollId}`, String(optionIndex), 1);
+		return true;
+	},
+
+	/**
+	 * Get aggregate counts for all options in a poll
+	 */
+	async getCounts(pollId) {
+		const counts = await db.getObject(`poll:counts:${pollId}`) || {};
+		const out = {};
+		for (const k of Object.keys(counts)) {
+			out[k] = Number(counts[k]);
+		}
+		return out;
+	},
+
+	/**
+	 * Get the option a specific user voted for
+	 */
+	async getUserChoice(pollId, userId) {
+		const obj = await db.getObject(`poll:vote:${pollId}:${userId}`);
+		if (!obj || typeof obj.optionIndex === 'undefined') {
+			return null;
+		}
+		return Number(obj.optionIndex);
+	},
+};
+
+module.exports = Votes;

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -4,15 +4,72 @@ const express = require('express');
 
 const uploadsController = require('../controllers/uploads');
 const helpers = require('./helpers');
+const Polls = require('../polls/model');
+const Votes = require('../polls/votes');
+
 
 module.exports = function (app, middleware, controllers) {
 	const middlewares = [middleware.autoLocale, middleware.authenticateRequest];
 	const router = express.Router();
 	app.use('/api', router);
+	
+	// GET /api/posts/:pid/poll
+	async function getPollForPost(req, res, next) {
+	try {
+		const pid = parseInt(req.params.pid, 10);
+		if (!Number.isInteger(pid)) {
+		return res.status(400).json({ error: 'bad pid' });
+		}
+
+		const poll = await Polls.getPollByPostId(pid);
+		if (!poll) {
+		return res.json({ postId: pid, poll: {} });
+		}
+
+		const uid = (req.user && req.user.uid) || 0;
+		const hasVoted = uid ? await Votes.hasUserVoted(poll.pollId, uid) : false;
+		const selectedOptionIndex = hasVoted ? await Votes.getUserChoice(poll.pollId, uid) : null;
+
+		// Shape options for the client: [{ index, text }]
+		const options = Array.isArray(poll.options)
+		? poll.options.map((text, index) => ({ index, text }))
+		: [];
+
+		// Show counts after the user has voted 
+		let counts = null;
+		let totalVotes = null;
+		if (hasVoted) {
+		// Votes.getCounts returns an object like { "0": 3, "1": 5 }
+		const obj = await Votes.getCounts(poll.pollId);
+		counts = options.map(o => Number(obj?.[o.index] || 0)); 
+		totalVotes = counts.reduce((a, b) => a + b, 0);
+		}
+
+		return res.json({
+		postId: pid,
+		poll: {
+			id: String(poll.pollId),
+			question: poll.question || '',
+			options,                       
+			hasVoted,
+			selectedOptionIndex,           // single-choice model
+			counts,                        // null until user votes
+			totalVotes,                     // null until user votes
+			allowsMultiple: false,
+			allowsViewResultsBeforeVote: false,
+		},
+		});
+	} catch (err) {
+		next(err);
+	}
+	}
+
 
 	router.get('/config', [...middlewares, middleware.applyCSRF], helpers.tryRoute(controllers.api.getConfig));
 
 	router.get('/self', [...middlewares], helpers.tryRoute(controllers.user.getCurrentUser));
+	router.get('/posts/:pid/poll', [...middlewares], helpers.tryRoute(getPollForPost));
+
 	router.get('/user/uid/:uid', [...middlewares, middleware.canViewUsers], helpers.tryRoute(controllers.user.getUserByUID));
 	router.get('/user/username/:username', [...middlewares, middleware.canViewUsers], helpers.tryRoute(controllers.user.getUserByUsername));
 	router.get('/user/email/:email', [...middlewares, middleware.canViewUsers], helpers.tryRoute(controllers.user.getUserByEmail));

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -15,53 +15,53 @@ module.exports = function (app, middleware, controllers) {
 	
 	// GET /api/posts/:pid/poll
 	async function getPollForPost(req, res, next) {
-	try {
-		const pid = parseInt(req.params.pid, 10);
-		if (!Number.isInteger(pid)) {
-		return res.status(400).json({ error: 'bad pid' });
+		try {
+			const pid = parseInt(req.params.pid, 10);
+			if (!Number.isInteger(pid)) {
+				return res.status(400).json({ error: 'bad pid' });
+			}
+
+			const poll = await Polls.getPollByPostId(pid);
+			if (!poll) {
+				return res.json({ postId: pid, poll: {} });
+			}
+
+			const uid = (req.user && req.user.uid) || 0;
+			const hasVoted = uid ? await Votes.hasUserVoted(poll.pollId, uid) : false;
+			const selectedOptionIndex = hasVoted ? await Votes.getUserChoice(poll.pollId, uid) : null;
+
+			// Shape options for the client: [{ index, text }]
+			const options = Array.isArray(poll.options) ?
+				poll.options.map((text, index) => ({ index, text })) :
+				[];
+
+			// Show counts after the user has voted 
+			let counts = null;
+			let totalVotes = null;
+			if (hasVoted) {
+				// Votes.getCounts returns an object like { "0": 3, "1": 5 }
+				const obj = await Votes.getCounts(poll.pollId);
+				counts = options.map(o => Number(obj?.[o.index] || 0)); 
+				totalVotes = counts.reduce((a, b) => a + b, 0);
+			}
+
+			return res.json({
+				postId: pid,
+				poll: {
+					id: String(poll.pollId),
+					question: poll.question || '',
+					options,                       
+					hasVoted,
+					selectedOptionIndex, // single-choice model
+					counts, // null until user votes
+					totalVotes, // null until user votes
+					allowsMultiple: false,
+					allowsViewResultsBeforeVote: false,
+				},
+			});
+		} catch (err) {
+			next(err);
 		}
-
-		const poll = await Polls.getPollByPostId(pid);
-		if (!poll) {
-		return res.json({ postId: pid, poll: {} });
-		}
-
-		const uid = (req.user && req.user.uid) || 0;
-		const hasVoted = uid ? await Votes.hasUserVoted(poll.pollId, uid) : false;
-		const selectedOptionIndex = hasVoted ? await Votes.getUserChoice(poll.pollId, uid) : null;
-
-		// Shape options for the client: [{ index, text }]
-		const options = Array.isArray(poll.options)
-		? poll.options.map((text, index) => ({ index, text }))
-		: [];
-
-		// Show counts after the user has voted 
-		let counts = null;
-		let totalVotes = null;
-		if (hasVoted) {
-		// Votes.getCounts returns an object like { "0": 3, "1": 5 }
-		const obj = await Votes.getCounts(poll.pollId);
-		counts = options.map(o => Number(obj?.[o.index] || 0)); 
-		totalVotes = counts.reduce((a, b) => a + b, 0);
-		}
-
-		return res.json({
-		postId: pid,
-		poll: {
-			id: String(poll.pollId),
-			question: poll.question || '',
-			options,                       
-			hasVoted,
-			selectedOptionIndex,           // single-choice model
-			counts,                        // null until user votes
-			totalVotes,                     // null until user votes
-			allowsMultiple: false,
-			allowsViewResultsBeforeVote: false,
-		},
-		});
-	} catch (err) {
-		next(err);
-	}
 	}
 
 

--- a/test/polls.js
+++ b/test/polls.js
@@ -1,0 +1,60 @@
+'use strict';
+
+// Prime NodeBB require paths + use the mock DB (so this test doesn't hit real Redis)
+require('../require-main');
+require('./mocks/databasemock');
+
+const assert = require('assert');
+const Polls = require('../src/polls/model');
+const Votes = require('../src/polls/votes');
+
+describe('Polls Data Model (Issue 1)', function () {
+	let pollId;
+
+	it('creates a poll with question + options', async function () {
+		const poll = await Polls.createPoll({
+			postId: 'post-123',
+			question: 'Which chapter?',
+			options: ['Ch3', 'Ch4', 'Ch5'],
+			createdBy: 'ta-42',
+		});
+		pollId = poll.pollId;
+
+		assert.ok(pollId);
+		assert.strictEqual(poll.postId, 'post-123');
+		assert.strictEqual(poll.question, 'Which chapter?');
+		assert.deepStrictEqual(poll.options, ['Ch3', 'Ch4', 'Ch5']);
+	});
+
+	it('rejects polls with fewer than 2 options', async function () {
+		let err;
+		try {
+			await Polls.createPoll({
+				postId: 'post-999',
+				question: 'Bad poll',
+				options: ['Only one'],
+				createdBy: 'ta-42',
+			});
+		} catch (e) { err = e; }
+		assert.ok(err, 'Expected an error for invalid poll');
+	});
+
+	it('allows a user to vote once', async function () {
+		const ok = await Votes.recordVote({ pollId, userId: 'u1', optionIndex: 1 });
+		assert.strictEqual(ok, true);
+	});
+
+	it('prevents double voting by same user and tracks counts', async function () {
+		let err;
+		try {
+			await Votes.recordVote({ pollId, userId: 'u1', optionIndex: 2 });
+		} catch (e) { err = e; }
+		assert.ok(err, 'Expected error when voting twice');
+		assert.strictEqual(err.code, 'ALREADY_VOTED');
+
+		await Votes.recordVote({ pollId, userId: 'u2', optionIndex: 2 });
+		const counts = await Votes.getCounts(pollId);
+		// After u1 voted option 1 and u2 voted option 2:
+		assert.deepStrictEqual(counts, { '0': 0, '1': 1, '2': 1 });
+	});
+});

--- a/vendor/nodebb-theme-harmony-2.1.15/library.js
+++ b/vendor/nodebb-theme-harmony-2.1.15/library.js
@@ -45,7 +45,7 @@ async function buildSkins() {
 		const plugins = require.main.require('./src/plugins');
 		await plugins.prepareForBuild(['client side styles']);
 		for (const skin of meta.css.supportedSkins) {
-			// eslint-disable-next-line no-await-in-loop
+			 
 			await meta.css.buildBundle(`client-${skin}`, true);
 		}
 		require.main.require('./src/meta/minifier').killAll();


### PR DESCRIPTION


## Summary
Add a read-only endpoint to fetch a post’s poll. Server enforces “show results only after vote” so clients can’t bypass UI logic.

## Changes
- **API**: `GET /api/posts/:pid/poll`
  - Post **with poll** → `{ question, options[], hasVoted, selectedOptionIndex, counts?, totalVotes? }`
  - Post **without poll** → `{}`
- **Backend**: wires into existing `Polls` + `Votes` models
- **Behavior**: if `hasVoted === false`, omit `counts` and `totalVotes`; after vote, include results

## Rationale
Single server-side source of truth for poll data; prevents viewing results before voting.

## Testing
Manual
```bash
# with a post that has a poll
curl -s http://localhost:4567/api/posts/<PID_WITH_POLL>/poll | jq
# expect: hasVoted false → no counts; after voting → counts & totalVotes present

# with a post that has no poll
curl -s http://localhost:4567/api/posts/<PID_WITHOUT>/poll | jq
# expect: {}
