### PR TITLE
Template Selector pop-up window

### DIFF
--- a/plugins/nodebb-plugin-template-selector/library.js
+++ b/plugins/nodebb-plugin-template-selector/library.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const Template = require.main.require('./src/templates');
+
+const Plugin = {};
+
+// This function runs when NodeBB starts and loads this plugin
+Plugin.init = function (params, callback) {
+  const router = params.router;
+  const middleware = params.middleware;
+
+	//GET API route to return a list of available templates
+  router.get('/api/plugins/template-selector/templates', middleware.requireUser, async function (req, res) {
+    try {
+      const templates = await Template.list();
+      const response = templates.map(t => ({ id: t.id, title: t.title }));
+
+			// Send the templates back to the browser as JSON
+      res.json({ templates: response }); 
+    } catch (err) {
+      console.error('Failed to load templates:', err);
+      res.status(500).json({ error: 'Failed to load templates' });
+    }
+  });
+
+  callback();
+};
+
+module.exports = Plugin;

--- a/plugins/nodebb-plugin-template-selector/package.json
+++ b/plugins/nodebb-plugin-template-selector/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nodebb-plugin-template-selector",
+  "version": "1.0.0",
+  "description": "Custom template selection plugin for admins",
+  "main": "library.js",
+  "keywords": [
+    "nodebb",
+    "plugin"
+  ],
+  "author": "IndyaG",
+  "license": "NIT"
+}

--- a/plugins/nodebb-plugin-template-selector/plugin.json
+++ b/plugins/nodebb-plugin-template-selector/plugin.json
@@ -1,0 +1,14 @@
+{
+  "id": "nodebb-plugin-template-selector",
+  "name": "Template Selector",
+  "description": "Add a template picker before opening composer.",
+  "url": "https://github.com/julianlam/nodebb-plugin-template-selector",
+  "library": "./library.js",
+  "scripts": ["static/template-popup.js"],
+  "hooks": [
+    {
+      "hook": "static:app.load",
+      "method": "init"
+    }
+  ]
+}

--- a/plugins/nodebb-plugin-template-selector/static/template-popup.js
+++ b/plugins/nodebb-plugin-template-selector/static/template-popup.js
@@ -1,0 +1,53 @@
+'use strict';
+
+// Wait for the page to fully load
+$(document).ready(function () {
+  $(document).on('click', '#new_topic', async function (e) {
+    e.preventDefault();
+
+    try {
+			// Make a request to the server to get the list of templates
+      const res = await fetch('/api/plugins/template-selector/templates', {
+        credentials: 'include',
+      });
+
+      if (!res.ok) throw new Error('Failed to fetch templates');
+
+      const data = await res.json();
+      const templates = data.templates || [];
+
+      // Add blank template at the end of the list
+      templates.push({ id: '', title: 'Blank Template' });
+
+      let html = '<form id="template-selection">';
+
+			// Loop through each template and add it as a radio button
+      templates.forEach(template => {
+        html += `<div><label><input type="radio" name="template" value="${template.id}" ${template.id === '' ? 'checked' : ''}> ${template.title}</label></div>`;
+      });
+      html += '</form>';
+
+			// Show a pop-up dialog using Bootbox to let the user choose a template
+      bootbox.dialog({
+        title: 'Select a Template',
+        message: html,
+        buttons: {
+          submit: {
+            label: 'Submit',
+            className: 'btn-primary',
+            callback: function () {
+              const selected = $('#template-selection input[name=template]:checked').val() || '';
+              const href = $('#new_topic').attr('href');
+              const url = selected ? `${href}&template=${encodeURIComponent(selected)}` : href;
+              window.location.href = url;
+            },
+          },
+        },
+        onEscape: false,
+        backdrop: 'static',
+      });
+    } catch (err) {
+      alert(err.message);
+    }
+  });
+});


### PR DESCRIPTION
## Summary 

When admins click on "New Topic," a popup appears allowing them to select from a list of predefined templates stored in the database. This helps admins structure posts consistently by applying specific templates before composing the content. The "Blank Template" option is always positioned at the bottom of the list, allowing users to start with a clean slate if desired.

The feature includes:
- An API endpoint to fetch available templates
- A dynamic popup UI to select a template before launching the post text field area

## Testing
I tested it locally by running `./nodebb build` & `./nodebb start` or `./nodebb restart`

Feature Testing Includes:
- Verified the template selector popup appears on clicking "New Topic"
- Confirmed the "Blank Template" is always listed at the bottom and selected by default.

<img width="2325" height="757" alt="Screenshot 2025-10-04 062821" src="https://github.com/user-attachments/assets/87506d84-a531-4a4c-96ba-2c0fe3c4a194" />

## Additional Testing & Implementation Notes
If NodeBB becomes stuck or the plugin causes loading issues, manually disable and re-enable the plugin through Redis CLI:

`redis-cli`
`ZREM plugins:active nodebb-plugin-template-selector    # Disable plugin`
ZADD plugins:active $(date +%s) nodebb-plugin-template-selector
Eaxmple: `ZADD plugins:active 1696447600 nodebb-plugin-template-selector   # Re-enable plugin`

I created a custom nodebb plugin and linked it using these commands:
1. `cd plugins/nodebb-plugin-template-selector`
2. `npm link`
3. `cd` back into root directory for nodegpt repo
4. `npm link nodebb-plugin-template-selector`
5. `./nodebb build `
6. `./nodebb restart`

Closes #6 
